### PR TITLE
To make the EPM client work when ElasTest works as a server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>epm.client</artifactId>
   <packaging>jar</packaging>
   <name>epm-java-client</name>
-  <version>0.1.0</version>
+  <version>0.9.0</version>
   <url>https://github.com/swagger-api/swagger-codegen</url>
   <description>Swagger Java</description>
   <scm>
@@ -173,14 +173,14 @@
       <version>${swagger-core-version}</version>
     </dependency>
     <dependency>
-      <groupId>com.squareup.okhttp</groupId>
+      <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
       <version>${okhttp-version}</version>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp</groupId>
       <artifactId>logging-interceptor</artifactId>
-      <version>${okhttp-version}</version>
+      <version>${okhttp-loggin-interceptor-version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
@@ -212,7 +212,8 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <swagger-core-version>1.5.12</swagger-core-version>
-    <okhttp-version>2.7.5</okhttp-version>
+    <okhttp-version>3.8.0</okhttp-version>
+    <okhttp-loggin-interceptor-version>2.7.5</okhttp-loggin-interceptor-version>
     <gson-version>2.6.2</gson-version>
     <jodatime-version>2.9.3</jodatime-version>
     <maven-plugin-version>0.1.0</maven-plugin-version>

--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
       <version>1.7.25</version>
-      <scope>test</scope>
+      
     </dependency>
     <!-- test dependencies -->
     <dependency>

--- a/src/main/java/io/elastest/epm/client/ApiClient.java
+++ b/src/main/java/io/elastest/epm/client/ApiClient.java
@@ -1028,6 +1028,7 @@ public class ApiClient {
         try {
           respBody = response.body().string();
         } catch (IOException e) {
+            e.printStackTrace();            
           throw new ApiException(
               response.message(), e, response.code(), response.headers().toMultimap());
         }

--- a/src/main/java/io/elastest/epm/client/ApiClient.java
+++ b/src/main/java/io/elastest/epm/client/ApiClient.java
@@ -12,23 +12,6 @@
 
 package io.elastest.epm.client;
 
-import com.squareup.okhttp.Call;
-import com.squareup.okhttp.Callback;
-import com.squareup.okhttp.FormEncodingBuilder;
-import com.squareup.okhttp.Headers;
-import com.squareup.okhttp.MediaType;
-import com.squareup.okhttp.MultipartBuilder;
-import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.Request;
-import com.squareup.okhttp.RequestBody;
-import com.squareup.okhttp.Response;
-import com.squareup.okhttp.internal.http.HttpMethod;
-import com.squareup.okhttp.logging.HttpLoggingInterceptor;
-import com.squareup.okhttp.logging.HttpLoggingInterceptor.Level;
-import io.elastest.epm.client.auth.ApiKeyAuth;
-import io.elastest.epm.client.auth.Authentication;
-import io.elastest.epm.client.auth.HttpBasicAuth;
-import io.elastest.epm.client.auth.OAuth;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -58,6 +41,7 @@ import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
@@ -65,6 +49,28 @@ import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.squareup.okhttp.Call;
+import com.squareup.okhttp.Callback;
+import com.squareup.okhttp.FormEncodingBuilder;
+import com.squareup.okhttp.Headers;
+import com.squareup.okhttp.MediaType;
+import com.squareup.okhttp.MultipartBuilder;
+import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Request;
+import com.squareup.okhttp.RequestBody;
+import com.squareup.okhttp.Response;
+import com.squareup.okhttp.internal.http.HttpMethod;
+import com.squareup.okhttp.logging.HttpLoggingInterceptor;
+import com.squareup.okhttp.logging.HttpLoggingInterceptor.Level;
+
+import io.elastest.epm.client.auth.ApiKeyAuth;
+import io.elastest.epm.client.auth.Authentication;
+import io.elastest.epm.client.auth.HttpBasicAuth;
+import io.elastest.epm.client.auth.OAuth;
 import okio.BufferedSink;
 import okio.Okio;
 
@@ -102,6 +108,9 @@ public class ApiClient {
     ET_EPM_API = System.getenv("ET_EPM_API");
     ET_PUBLIC_HOST = System.getenv("ET_PUBLIC_HOST");
   }
+  
+  private static final Logger logger = LoggerFactory
+          .getLogger(ApiClient.class);
 
   /** The datetime format to be used when <code>lenientDatetimeFormat</code> is enabled. */
   public static final String LENIENT_DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
@@ -162,6 +171,7 @@ public class ApiClient {
     
     if (ET_PUBLIC_HOST != null) {
         basePath = "http://" + ET_PUBLIC_HOST + ":" + ET_EPM_API.split("epm:")[1];
+        logger.info("EPM URL: " + basePath);
     }   
   }
 

--- a/src/main/java/io/elastest/epm/client/ApiClient.java
+++ b/src/main/java/io/elastest/epm/client/ApiClient.java
@@ -170,7 +170,7 @@ public class ApiClient {
     httpClient.setReadTimeout(3600, TimeUnit.SECONDS);
     
     if (ET_PUBLIC_HOST != null) {
-        basePath = "http://" + ET_PUBLIC_HOST + ":" + ET_EPM_API.split("epm:/")[1];
+        basePath = "http://" + ET_PUBLIC_HOST + ":" + ET_EPM_API.split("epm:")[1].split("/")[1];
         logger.info("EPM URL: " + basePath);
     }   
   }

--- a/src/main/java/io/elastest/epm/client/ApiClient.java
+++ b/src/main/java/io/elastest/epm/client/ApiClient.java
@@ -1033,6 +1033,7 @@ public class ApiClient {
               response.message(), e, response.code(), response.headers().toMultimap());
         }
       }
+      logger.error(response.message() + ":" + ":" + respBody);
       throw new ApiException(
           response.message(), response.code(), response.headers().toMultimap(), respBody);
     }

--- a/src/main/java/io/elastest/epm/client/ApiClient.java
+++ b/src/main/java/io/elastest/epm/client/ApiClient.java
@@ -172,7 +172,7 @@ public class ApiClient {
     httpClient.setReadTimeout(3600, TimeUnit.SECONDS);
     
     if (ET_PUBLIC_HOST != null) {
-        basePath = "http://" + ET_PUBLIC_HOST + ":" + ET_EPM_BINDED_PORT;
+        basePath = "http://" + ET_PUBLIC_HOST + ":" + ET_EPM_BINDED_PORT + "/v1";
         logger.info("EPM URL: " + basePath);
     }   
   }

--- a/src/main/java/io/elastest/epm/client/ApiClient.java
+++ b/src/main/java/io/elastest/epm/client/ApiClient.java
@@ -80,6 +80,7 @@ public class ApiClient {
   public static final int ANDROID_SDK_VERSION;
   public static final String ET_EPM_API;
   public static final String ET_PUBLIC_HOST;
+  public static final String ET_EPM_BINDED_PORT;
 
   static {
     JAVA_VERSION = Double.parseDouble(System.getProperty("java.specification.version"));
@@ -107,6 +108,7 @@ public class ApiClient {
     ANDROID_SDK_VERSION = sdkVersion;
     ET_EPM_API = System.getenv("ET_EPM_API");
     ET_PUBLIC_HOST = System.getenv("ET_PUBLIC_HOST");
+    ET_EPM_BINDED_PORT = System.getenv("ET_EPM_BINDED_PORT");
   }
   
   private static final Logger logger = LoggerFactory
@@ -170,7 +172,7 @@ public class ApiClient {
     httpClient.setReadTimeout(3600, TimeUnit.SECONDS);
     
     if (ET_PUBLIC_HOST != null) {
-        basePath = "http://" + ET_PUBLIC_HOST + ":" + ET_EPM_API.split("epm:")[1].split("/")[0];
+        basePath = "http://" + ET_PUBLIC_HOST + ":" + ET_EPM_BINDED_PORT;
         logger.info("EPM URL: " + basePath);
     }   
   }

--- a/src/main/java/io/elastest/epm/client/ApiClient.java
+++ b/src/main/java/io/elastest/epm/client/ApiClient.java
@@ -1117,6 +1117,7 @@ public class ApiClient {
    */
   public String buildUrl(String path, List<Pair> queryParams) {
     final StringBuilder url = new StringBuilder();
+    
     url.append(basePath).append(path);
 
     if (queryParams != null && !queryParams.isEmpty()) {
@@ -1135,6 +1136,8 @@ public class ApiClient {
         }
       }
     }
+    
+    logger.info("Api EPM URL: " + url.toString());
 
     return url.toString();
   }

--- a/src/main/java/io/elastest/epm/client/ApiClient.java
+++ b/src/main/java/io/elastest/epm/client/ApiClient.java
@@ -72,6 +72,7 @@ public class ApiClient {
   public static final double JAVA_VERSION;
   public static final boolean IS_ANDROID;
   public static final int ANDROID_SDK_VERSION;
+  public static final String ET_EPM_API;
 
   static {
     JAVA_VERSION = Double.parseDouble(System.getProperty("java.specification.version"));
@@ -97,6 +98,7 @@ public class ApiClient {
       }
     }
     ANDROID_SDK_VERSION = sdkVersion;
+    ET_EPM_API = System.getenv("ET_EPM_API");
   }
 
   /** The datetime format to be used when <code>lenientDatetimeFormat</code> is enabled. */
@@ -155,6 +157,8 @@ public class ApiClient {
     authentications = Collections.unmodifiableMap(authentications);
 
     httpClient.setReadTimeout(3600, TimeUnit.SECONDS);
+    
+    basePath = ET_EPM_API != null ?ET_EPM_API : basePath;
   }
 
   /**

--- a/src/main/java/io/elastest/epm/client/ApiClient.java
+++ b/src/main/java/io/elastest/epm/client/ApiClient.java
@@ -170,7 +170,7 @@ public class ApiClient {
     httpClient.setReadTimeout(3600, TimeUnit.SECONDS);
     
     if (ET_PUBLIC_HOST != null) {
-        basePath = "http://" + ET_PUBLIC_HOST + ":" + ET_EPM_API.split("epm:")[1].split("/")[1];
+        basePath = "http://" + ET_PUBLIC_HOST + ":" + ET_EPM_API.split("epm:")[1].split("/")[0];
         logger.info("EPM URL: " + basePath);
     }   
   }

--- a/src/main/java/io/elastest/epm/client/ApiClient.java
+++ b/src/main/java/io/elastest/epm/client/ApiClient.java
@@ -170,7 +170,7 @@ public class ApiClient {
     httpClient.setReadTimeout(3600, TimeUnit.SECONDS);
     
     if (ET_PUBLIC_HOST != null) {
-        basePath = "http://" + ET_PUBLIC_HOST + ":" + ET_EPM_API.split("epm:")[1];
+        basePath = "http://" + ET_PUBLIC_HOST + ":" + ET_EPM_API.split("epm:/")[1];
         logger.info("EPM URL: " + basePath);
     }   
   }

--- a/src/main/java/io/elastest/epm/client/ApiClient.java
+++ b/src/main/java/io/elastest/epm/client/ApiClient.java
@@ -73,6 +73,7 @@ public class ApiClient {
   public static final boolean IS_ANDROID;
   public static final int ANDROID_SDK_VERSION;
   public static final String ET_EPM_API;
+  public static final String ET_PUBLIC_HOST;
 
   static {
     JAVA_VERSION = Double.parseDouble(System.getProperty("java.specification.version"));
@@ -99,6 +100,7 @@ public class ApiClient {
     }
     ANDROID_SDK_VERSION = sdkVersion;
     ET_EPM_API = System.getenv("ET_EPM_API");
+    ET_PUBLIC_HOST = System.getenv("ET_PUBLIC_HOST");
   }
 
   /** The datetime format to be used when <code>lenientDatetimeFormat</code> is enabled. */
@@ -158,7 +160,9 @@ public class ApiClient {
 
     httpClient.setReadTimeout(3600, TimeUnit.SECONDS);
     
-    basePath = ET_EPM_API != null ?ET_EPM_API : basePath;
+    if (ET_PUBLIC_HOST != null) {
+        basePath = "http://" + ET_PUBLIC_HOST + ":" + ET_EPM_API.split("epm:")[1];
+    }   
   }
 
   /**


### PR DESCRIPTION
- If environment variables ET_PUBLIC_HOST and ET_EPM_BINDED_PORT exist, replace the default basepath value with "http://" + ET_PUBLIC_HOST + ":" + ET_EPM_BINDED_PORT + "/v1".

- Modify the version of the artifact in the pom to match the version of the documentation

